### PR TITLE
Fix missing ? to delineate query string

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ First configure the basic parameters, either using a DSN or as separate paramete
 
 ```yaml
 unleash_client:
-  dsn: http://localhost:4242/api&instance_id=myCoolApp-Server1&app_name=myCoolApp
+  dsn: http://localhost:4242/api?instance_id=myCoolApp-Server1&app_name=myCoolApp
 ```
 
 or


### PR DESCRIPTION
Replace `&` in query string with `?` to create a valid URL

Fixes #65
